### PR TITLE
Fix Anonymous User WebCall 500 Error

### DIFF
--- a/src/main/java/com/gs/config/AuditorConfig.java
+++ b/src/main/java/com/gs/config/AuditorConfig.java
@@ -8,13 +8,15 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Optional;
 
 /**
- * @author guozhenyua
+ * @author 
  * @version 1.0
  * @description
  * @createTime 2019/3/9
  **/
 @Configuration
 public class AuditorConfig implements AuditorAware<String> {
+    @Override
+    public Optional<String> getCurrentAuditor() {
         Object principalOrAnonymous = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (principalOrAnonymous.getClass().equals(String.class))
         {

--- a/src/main/java/com/gs/config/AuditorConfig.java
+++ b/src/main/java/com/gs/config/AuditorConfig.java
@@ -15,9 +15,12 @@ import java.util.Optional;
  **/
 @Configuration
 public class AuditorConfig implements AuditorAware<String> {
-    @Override
-    public Optional<String> getCurrentAuditor() {
-        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return Optional.ofNullable(userDetails.getUsername());
+        Object principalOrAnonymous = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principalOrAnonymous.getClass().equals(String.class))
+        {
+            return null;
+        }else {
+            return Optional.ofNullable(((UserDetails)principalOrAnonymous).getUsername());
+        }
     }
 }


### PR DESCRIPTION
When anonymous call a function, getPrincipal() returns a string, Occor a convert error.
I fixed it with a coditional statement. if anonymous call a function, getCurrentAuditor() will returen a null object. If a logined user call a function, getCurrentAuditor() will returen as normal.